### PR TITLE
Add gardenctl target and shell support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline_temp$",
     "lines": null
   },
-  "generated_at": "2019-07-02T14:45:08Z",
+  "generated_at": "2019-07-04T11:37:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -34,7 +34,7 @@
       {
         "hashed_secret": "30118aa1aa8a06fa5365743b3a5db69fc62b9760",
         "is_secret": false,
-        "line_number": 274,
+        "line_number": 479,
         "type": "Secret Keyword"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This vs-code extension allows you to work with your gardener projects, shoots, p
 
 ## Requirements
 - You have installed the [Kubernetes Tools](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension from the marketplace
+- [Gardenctl](https://github.com/gardener/gardenctl#installation) for `Shell` or `Target` command
 - Kubeconfig to (virtual) garden cluster
 
 ## Install from VSIX
@@ -35,6 +36,7 @@ This extension contributes the following settings:
 * `vscode-gardener-tools.vscode-light-theme`: should match your configured theme style. Default: true
 * `vscode-gardener-tools.landscapes`: Required configuration for garden landscapes
 * `vscode-gardener-tools.landscapes[].name`: Name of the garden cluster
+* `vscode-gardener-tools.landscapes[].gardenName`: Optional name of the corresponding (gardenctl) garden. Default: Name of the landscape
 * `vscode-gardener-tools.landscapes[].kubeconfigPath`: Path to the kubeconfig of the garden cluster
 * `vscode-gardener-tools.landscapes[].dashboardUrl`: Gardener dashboard URL,
 * `vscode-gardener-tools.landscapes[].projects`: Optional list of projects (names) to be shown. However, you should specify this list if you do not have operator rights on the garden cluster or if you want to see only those projects.
@@ -46,12 +48,13 @@ Example config settings.json:
       "landscapes": [
         {
           "name": "landscape-dev",
+          "gardenName": "virtual-dev",
           "kubeconfigPath": "/kubeconfigpath/cluster-dev-virtual-garden/kubeconfig.yaml",
           "dashboardUrl": "https://dashboard.garden.dev.example.com",
           "projects": ["garden", "myproject"]
         },
         {
-          "name": "landscape-peter",
+          "name": "landscape-canary",
           "kubeconfigPath": "/kubeconfigpath/cluster-canary-virtual-garden/kubeconfig.yaml",
           "dashboardUrl": "https://dashboard.garden.canary.example.com"
         },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This vs-code extension allows you to work with your gardener projects, shoots, plants and seeds.
 
-<img src="https://user-images.githubusercontent.com/5526658/60441576-8f11cc80-9c17-11e9-9210-ab392d57c63e.png" alt="VScode Gardener Tools Screenshot" width="600"/>
+<img src="https://user-images.githubusercontent.com/5526658/60663851-a8f22000-9e60-11e9-99e0-11a6a4313fb4.png" alt="VScode Gardener Tools Screenshot" width="600"/>
 
 ## Features
 
@@ -14,6 +14,9 @@ This vs-code extension allows you to work with your gardener projects, shoots, p
 - Right click landscape or shoot to `Show In Dashboard`
 - Right click on landscape to `Create Project` in gardener dashboard
 - Right click on shoots list to `Create Shoot` in gardener dashboard
+- [Gardenctl](https://github.com/gardener/gardenctl) integration
+  - Right click on shoot or seed to create a `Shell` into a node
+  - Right click on landscape, project, shoot or seed to `Target` with gardenctl
 
 ## Requirements
 - You have installed the [Kubernetes Tools](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension from the marketplace
@@ -23,7 +26,7 @@ This vs-code extension allows you to work with your gardener projects, shoots, p
 
 * Download .vsix file from latest [release](https://github.com/gardener/vscode-gardener-tools/releases) asset
 * In VSCode, open the [command palette](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette): `View` -> `Command Palette...` -> type in `Extensions: Install from VSIX...`
-* Choose .vsix file downloaded in first step 
+* Choose .vsix file downloaded in first step
 
 ## Extension Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,8 +242,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -258,7 +257,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -353,8 +351,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -597,6 +594,17 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -678,8 +686,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -700,7 +707,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -844,7 +850,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -853,8 +858,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "6.4.1",
@@ -893,6 +897,11 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1028,7 +1037,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1141,7 +1149,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1187,8 +1194,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -1201,6 +1207,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -1244,6 +1255,14 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -1284,6 +1303,14 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1304,7 +1331,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -1359,6 +1385,16 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -1511,12 +1547,11 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "rimraf": "^2.6.3"
       }
     },
     "to-fast-properties": {
@@ -1674,8 +1709,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
                     "type": "string",
                     "description": "Name of the garden cluster"
                   },
+                  "gardenName": {
+                    "type": "string",
+                    "description": "Optional Name of the corresponding (gardenctl) garden. Default: Name of the landscape"
+                  },
                   "kubeconfigPath": {
                     "type": "string",
                     "description": "Path to the kubeconfig of the garden cluster"
@@ -86,6 +90,16 @@
         "command": "vs-gardener.createProject",
         "title": "Create Project",
         "category": "Gardener"
+      },
+      {
+        "command": "vs-gardener.target",
+        "title": "Target",
+        "category": "Gardener"
+      },
+      {
+        "command": "vs-gardener.shell",
+        "title": "Shell",
+        "category": "Gardener"
       }
     ],
     "menus": {
@@ -113,12 +127,37 @@
         {
           "command": "vs-gardener.createProject",
           "when": "viewItem =~ /gardener\\.landscape/i"
+        },
+        {
+          "command": "vs-gardener.target",
+          "when": "viewItem =~ /gardener\\.landscape/i"
+        },
+        {
+          "command": "vs-gardener.target",
+          "when": "viewItem =~ /gardener\\.project/i"
+        },
+        {
+          "command": "vs-gardener.target",
+          "when": "viewItem =~ /gardener\\.shoot/i"
+        },
+        {
+          "command": "vs-gardener.target",
+          "when": "viewItem =~ /gardener\\.seed/i"
+        },
+        {
+          "command": "vs-gardener.shell",
+          "when": "viewItem =~ /gardener\\.shoot(?!\\.hibernated)/i"
+        },
+        {
+          "command": "vs-gardener.shell",
+          "when": "viewItem =~ /gardener\\.seed/i"
         }
       ]
     }
   },
   "scripts": {
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "lint": "eslint --ext .js src"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
@@ -130,6 +169,8 @@
   },
   "dependencies": {
     "lodash": "^4.17.11",
+    "shelljs": "^0.8.3",
+    "tmp": "^0.1.0",
     "url-join": "^4.0.0",
     "vscode-kubernetes-tools-api": "^1.0.0"
   }

--- a/src/gardener/client.js
+++ b/src/gardener/client.js
@@ -19,18 +19,16 @@
 const k8s = require('vscode-kubernetes-tools-api')
 const _ = require('lodash')
 
-const {
-  configForLandscape
-} = require('./utils')
+const { configForLandscape } = require('./utils')
 
 class Kubectl {
-  constructor(kubeconfig, namespace) {
+  constructor (kubeconfig, namespace) {
     this.kubeconfig = kubeconfig
     this.namespace = namespace
   }
 
-  async cmd(command, parseFormat = 'json') {
-    const kubectl = await k8s.extension.kubectl.v1;
+  async cmd (command, parseFormat = 'json') {
+    const kubectl = await k8s.extension.kubectl.v1
     if (!kubectl.available) {
       throw new Error('kubectl not available')
     }
@@ -48,44 +46,51 @@ class Kubectl {
         throw new Error(`unknown outputForm ${parseFormat}`)
     }
   }
-
 }
 
 class Client extends Kubectl {
-  constructor(kubeconfig, namespace, kindPlural) {
+  constructor (kubeconfig, namespace, kindPlural) {
     super(kubeconfig, namespace)
     this.kindPlural = kindPlural
   }
 
-  namespaceSelector() {
+  namespaceSelector () {
     if (this.namespace) {
       return `-n ${this.namespace}`
     }
     return ''
   }
 
-  async list() {
-    const { items } = await this.cmd(`get ${this.kindPlural} ${this.namespaceSelector()} -o json --kubeconfig ${this.kubeconfig}`)
+  async list () {
+    const { items } = await this.cmd(
+      `get ${this.kindPlural} ${this.namespaceSelector()} -o json --kubeconfig ${this.kubeconfig}`
+    )
     return items
   }
 
-  async get(name, outputFormat = 'json') {
-    return this.cmd(`get ${this.kindPlural}/${name} -n ${this.namespace} -o ${outputFormat} --kubeconfig ${this.kubeconfig}`)
+  async get (name, outputFormat = 'json') {
+    return this.cmd(
+      `get ${this.kindPlural}/${name} -n ${this.namespace} -o ${outputFormat} --kubeconfig ${this.kubeconfig}`
+    )
   }
 }
 
 class ProjectClient extends Client {
-  constructor(kubeconfig, landscapeName) {
+  constructor (kubeconfig, landscapeName) {
     const namespace = undefined // Project is a cluster scoped resource
     super(kubeconfig, namespace, 'projects')
     this.landscapeName = landscapeName
   }
 
-  async list() {
+  async list () {
     const config = configForLandscape(this.landscapeName)
     const projectNames = _.get(config, 'projects')
     if (!_.isEmpty(projectNames)) {
-      const promises = _.map(projectNames, projectName => this.cmd(`get project ${projectName} -o json --kubeconfig ${this.kubeconfig}`).catch((err) => { console.log(err) }))
+      const promises = _.map(projectNames, projectName =>
+        this.cmd(`get project ${projectName} -o json --kubeconfig ${this.kubeconfig}`).catch(err => {
+          console.log(err)
+        })
+      )
       let projects = await Promise.all(promises)
       projects = _.filter(projects, project => project !== undefined)
       return projects
@@ -96,55 +101,56 @@ class ProjectClient extends Client {
 }
 
 class ShootClient extends Client {
-  constructor(kubeconfig, namespace) {
+  constructor (kubeconfig, namespace) {
     super(kubeconfig, namespace, 'shoots')
   }
 }
 
 class PlantClient extends Client {
-  constructor(kubeconfig, namespace) {
+  constructor (kubeconfig, namespace) {
     super(kubeconfig, namespace, 'plants')
   }
 }
 
 class SeedClient extends Client {
-  constructor(kubeconfig) {
+  constructor (kubeconfig) {
     const namespace = undefined // CloudProfile is a cluster scoped resource
     super(kubeconfig, namespace, 'seeds')
   }
 }
 
 class SecretClient extends Client {
-  constructor(kubeconfig, namespace) {
+  constructor (kubeconfig, namespace) {
     super(kubeconfig, namespace, 'secrets')
   }
 }
 
 class CloudProfileClient extends Client {
-  constructor(kubeconfig) {
+  constructor (kubeconfig) {
     const namespace = undefined // CloudProfile is a cluster scoped resource
     super(kubeconfig, namespace, 'cloudprofiles')
   }
 }
 
 class NodeClient extends Client {
-  constructor(kubeconfig) {
+  constructor (kubeconfig) {
     const namespace = undefined // Nodes is a cluster scoped resource
     super(kubeconfig, namespace, 'nodes')
   }
 }
 
 class SelfSubjectAccessReviewClient extends Kubectl {
-  constructor(kubeconfig) {
+  constructor (kubeconfig) {
     const namespace = undefined
     super(kubeconfig, namespace)
   }
 
-  async canI(verb, kindPlural) {
-    const res = _.trim(await this.cmd(`auth can-i ${verb} ${kindPlural} --kubeconfig ${this.kubeconfig}`, 'raw')
-      .catch((err) => {
+  async canI (verb, kindPlural) {
+    const res = _.trim(
+      await this.cmd(`auth can-i ${verb} ${kindPlural} --kubeconfig ${this.kubeconfig}`, 'raw').catch(err => {
         console.log(err)
-      }))
+      })
+    )
     return res === 'yes'
   }
 }

--- a/src/gardener/gardener-tree.js
+++ b/src/gardener/gardener-tree.js
@@ -87,8 +87,9 @@ class GardenerTreeProvider {
       const treeItem = new vscode.TreeItem(
         label,
         vscode.TreeItemCollapsibleState.None
-        )
-      treeItem.contextValue = `gardener.shoot ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
+      )
+      const hibernated = element.hibernated ? '.hibernated' : ''
+      treeItem.contextValue = `gardener.shoot${hibernated} ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
       treeItem.iconPath = infraIcon(element.cloudType)
       treeItem.tooltip = shootTooltip(element)
@@ -97,7 +98,7 @@ class GardenerTreeProvider {
       const treeItem = new vscode.TreeItem(
         getDisplayName(element),
         vscode.TreeItemCollapsibleState.None
-        )
+      )
       treeItem.contextValue = `gardener.plant ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
       treeItem.iconPath = infraIcon(element.cloudType)
@@ -107,7 +108,7 @@ class GardenerTreeProvider {
       const treeItem = new vscode.TreeItem(
         getDisplayName(element),
         vscode.TreeItemCollapsibleState.None
-        )
+      )
       treeItem.contextValue = `gardener.seed ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
       treeItem.iconPath = infraIcon(element.cloudType)
@@ -139,7 +140,7 @@ class GardenerTreeProvider {
 
 module.exports = { GardenerTreeProvider, nodeType }
 
-function getLoadResourceCommand (element) {
+function getLoadResourceCommand(element) {
   return {
     command: 'vs-gardener.loadResource',
     title: 'Load',
@@ -147,7 +148,7 @@ function getLoadResourceCommand (element) {
   }
 }
 
-function getDisplayName (element) {
+function getDisplayName(element) {
   return element.displayName || element.name
 }
 
@@ -168,7 +169,7 @@ function asLandscapeTreeNode(name, kubeconfig) {
   }
 }
 
-async function clusterScopedResources (landscape) {
+async function clusterScopedResources(landscape) {
   const accessReview = new SelfSubjectAccessReviewClient(landscape.kubeconfig)
   const canIGetSeeds = await accessReview.canI('get', 'seeds')
   const clusterScopedResources = [
@@ -340,33 +341,33 @@ function seedTooltip(element) {
   return list.join('\n')
 }
 
-function getCloudType (object) {
+function getCloudType(object) {
   const cloudTypes = ['aws', 'azure', 'gcp', 'openstack', 'alicloud']
   return _.head(_.intersection(_.keys(object), cloudTypes))
 }
 
-function infraIcon (cloudType) {
+function infraIcon(cloudType) {
   const color = iconColor()
   let logo
-  switch(cloudType) {
+  switch (cloudType) {
     case 'aws':
       logo = `aws-${color}.svg`
       break
     case 'azure':
-        logo = `azure-${color}.svg`
-        break
+      logo = `azure-${color}.svg`
+      break
     case 'gcp':
-        logo = `gcp-${color}.svg`
-        break
+      logo = `gcp-${color}.svg`
+      break
     case 'openstack':
-        logo = `openstack-${color}.svg`
-        break
+      logo = `openstack-${color}.svg`
+      break
     case 'alicloud':
-        logo = `alicloud-${color}.svg`
-        break
+      logo = `alicloud-${color}.svg`
+      break
     case 'gce':
-        logo = `gce-${color}.svg`
-        break
+      logo = `gce-${color}.svg`
+      break
     case 'gke':
       logo = `gke-${color}.svg`
       break
@@ -376,7 +377,7 @@ function infraIcon (cloudType) {
   return vscode.Uri.file(path.join(__dirname, `../assets/${logo}`))
 }
 
-function iconColor () {
+function iconColor() {
   const config = vscode.workspace.getConfiguration('vscode-gardener-tools', null)
   const lightTheme = _.get(config, 'vscode-light-theme', true)
   if (lightTheme) {

--- a/src/gardener/gardener-tree.js
+++ b/src/gardener/gardener-tree.js
@@ -37,42 +37,30 @@ const nodeType = {
   NODE_TYPE_LANDSCAPE: 'landscape',
   NODE_TYPE_FOLDER: 'folder',
   NODE_TYPE_CLUSTER_TYPE: 'clusterType',
-  NODE_TYPE_ERROR: 'error',
+  NODE_TYPE_ERROR: 'error'
 }
 
 class GardenerTreeProvider {
-  constructor() {
+  constructor () {
     this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded
   }
 
-  getTreeItem(element) {
+  getTreeItem (element) {
     if (element.nodeType === nodeType.NODE_TYPE_ERROR) {
-      return new vscode.TreeItem(
-        element.message,
-        vscode.TreeItemCollapsibleState.None
-      )
+      return new vscode.TreeItem(element.message, vscode.TreeItemCollapsibleState.None)
     } else if (element.nodeType === nodeType.NODE_TYPE_LANDSCAPE) {
-      const treeItem = new vscode.TreeItem(
-        getDisplayName(element),
-        vscode.TreeItemCollapsibleState.Collapsed
-      )
+      const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.Collapsed)
       treeItem.iconPath = vscode.Uri.file(path.join(__dirname, '../assets/gardener-logo.svg'))
       treeItem.contextValue = `gardener.landscape ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       return treeItem
     } else if (element.nodeType === nodeType.NODE_TYPE_PROJECT) {
-      const treeItem = new vscode.TreeItem(
-        getDisplayName(element),
-        vscode.TreeItemCollapsibleState.Collapsed
-      )
+      const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.Collapsed)
       treeItem.contextValue = 'gardener.project'
       treeItem.tooltip = projectTooltip(element)
       treeItem.command = getLoadResourceCommand(element)
       return treeItem
     } else if (element.nodeType === nodeType.NODE_TYPE_FOLDER) {
-      const treeItem = new vscode.TreeItem(
-        getDisplayName(element),
-        vscode.TreeItemCollapsibleState.Collapsed
-      )
+      const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.Collapsed)
       const folderIcon = getFolderIcon(element.childType)
       if (folderIcon) {
         treeItem.iconPath = vscode.Uri.file(path.join(__dirname, '../assets/', folderIcon))
@@ -84,10 +72,7 @@ class GardenerTreeProvider {
       if (element.hibernated) {
         label = `${label} (zZz)`
       }
-      const treeItem = new vscode.TreeItem(
-        label,
-        vscode.TreeItemCollapsibleState.None
-      )
+      const treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None)
       const hibernated = element.hibernated ? '.hibernated' : ''
       treeItem.contextValue = `gardener.shoot${hibernated} ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
@@ -95,20 +80,14 @@ class GardenerTreeProvider {
       treeItem.tooltip = shootTooltip(element)
       return treeItem
     } else if (element.nodeType === nodeType.NODE_TYPE_PLANT) {
-      const treeItem = new vscode.TreeItem(
-        getDisplayName(element),
-        vscode.TreeItemCollapsibleState.None
-      )
+      const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.None)
       treeItem.contextValue = `gardener.plant ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
       treeItem.iconPath = infraIcon(element.cloudType)
       treeItem.tooltip = plantTooltip(element)
       return treeItem
     } else if (element.nodeType === nodeType.NODE_TYPE_SEED) {
-      const treeItem = new vscode.TreeItem(
-        getDisplayName(element),
-        vscode.TreeItemCollapsibleState.None
-      )
+      const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.None)
       treeItem.contextValue = `gardener.seed ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
       treeItem.iconPath = infraIcon(element.cloudType)
@@ -117,7 +96,7 @@ class GardenerTreeProvider {
     }
   }
 
-  getChildren(element) {
+  getChildren (element) {
     if (!element) {
       return landscapes()
     } else if (element.nodeType === nodeType.NODE_TYPE_LANDSCAPE) {
@@ -140,19 +119,21 @@ class GardenerTreeProvider {
 
 module.exports = { GardenerTreeProvider, nodeType }
 
-function getLoadResourceCommand(element) {
+function getLoadResourceCommand (element) {
   return {
     command: 'vs-gardener.loadResource',
     title: 'Load',
-    arguments: [element]
+    arguments: [
+      element
+    ]
   }
 }
 
-function getDisplayName(element) {
+function getDisplayName (element) {
   return element.displayName || element.name
 }
 
-async function landscapes() {
+async function landscapes () {
   const config = vscode.workspace.getConfiguration('vscode-gardener-tools', null)
   const landscapes = _.get(config, 'landscapes')
   return _.map(landscapes, landscape => {
@@ -161,15 +142,15 @@ async function landscapes() {
   })
 }
 
-function asLandscapeTreeNode(name, kubeconfig) {
+function asLandscapeTreeNode (name, kubeconfig) {
   return {
     nodeType: nodeType.NODE_TYPE_LANDSCAPE,
     name,
-    kubeconfig,
+    kubeconfig
   }
 }
 
-async function clusterScopedResources(landscape) {
+async function clusterScopedResources (landscape) {
   const accessReview = new SelfSubjectAccessReviewClient(landscape.kubeconfig)
   const canIGetSeeds = await accessReview.canI('get', 'seeds')
   const clusterScopedResources = [
@@ -181,7 +162,7 @@ async function clusterScopedResources(landscape) {
   return clusterScopedResources
 }
 
-async function projects({ parent: landscape }) {
+async function projects ({ parent: landscape }) {
   const projectClient = new ProjectClient(landscape.kubeconfig, landscape.name)
   const projects = await projectClient.list()
   return _.map(projects, project => {
@@ -189,7 +170,7 @@ async function projects({ parent: landscape }) {
   })
 }
 
-function toProjectTreeNode(landscape, project) {
+function toProjectTreeNode (landscape, project) {
   const name = _.get(project, 'metadata.name')
   return {
     nodeType: nodeType.NODE_TYPE_PROJECT,
@@ -204,23 +185,23 @@ function toProjectTreeNode(landscape, project) {
   }
 }
 
-function projectTooltip(element) {
+function projectTooltip (element) {
   const list = [
     `Project: ${element.name}`,
     `Owner: ${element.owner}`,
-    `Description: ${element.description}`,
+    `Description: ${element.description}`
   ]
   return list.join('\n')
 }
 
-function clusterTypes(project) {
+function clusterTypes (project) {
   return [
     toFolderTreeNode(project, 'Shoots', nodeType.NODE_TYPE_SHOOT),
     toFolderTreeNode(project, 'Plants', nodeType.NODE_TYPE_PLANT)
   ]
 }
 
-function toFolderTreeNode(parent, name, childType) {
+function toFolderTreeNode (parent, name, childType) {
   return {
     nodeType: nodeType.NODE_TYPE_FOLDER,
     childType,
@@ -229,7 +210,7 @@ function toFolderTreeNode(parent, name, childType) {
   }
 }
 
-async function shoots({ parent: project }) {
+async function shoots ({ parent: project }) {
   const shootClient = new ShootClient(project.landscape.kubeconfig, project.namespace)
   const shoots = await shootClient.list()
   return _.map(shoots, shoot => {
@@ -237,7 +218,7 @@ async function shoots({ parent: project }) {
   })
 }
 
-function toShootTreeNode(project, shoot) {
+function toShootTreeNode (project, shoot) {
   const name = _.get(shoot, 'metadata.name')
   return {
     nodeType: nodeType.NODE_TYPE_SHOOT,
@@ -254,17 +235,17 @@ function toShootTreeNode(project, shoot) {
   }
 }
 
-function shootTooltip(element) {
+function shootTooltip (element) {
   const list = [
     `Shoot: ${element.name}`,
     `Kubernetes Version: ${element.version}`,
     `Created By: ${element.createdBy}`,
-    `Purpose: ${element.purpose}`,
+    `Purpose: ${element.purpose}`
   ]
   return list.join('\n')
 }
 
-async function plants({ parent: project }) {
+async function plants ({ parent: project }) {
   const plant = new PlantClient(project.landscape.kubeconfig, project.namespace)
   const plants = await plant.list()
   return _.map(plants, plant => {
@@ -272,7 +253,7 @@ async function plants({ parent: project }) {
   })
 }
 
-function toPlantTreeNode(project, plant) {
+function toPlantTreeNode (project, plant) {
   const name = _.get(plant, 'metadata.name')
   return {
     nodeType: nodeType.NODE_TYPE_PLANT,
@@ -289,17 +270,17 @@ function toPlantTreeNode(project, plant) {
   }
 }
 
-function plantTooltip(element) {
+function plantTooltip (element) {
   const list = [
     `Plant: ${element.name}`,
     `Cloud: ${element.cloudType}/${element.region}`,
     `Kubernetes Version: ${element.version}`,
-    `Created By: ${element.createdBy}`,
+    `Created By: ${element.createdBy}`
   ]
   return list.join('\n')
 }
 
-async function seeds({ parent: landscape }) {
+async function seeds ({ parent: landscape }) {
   const seedClient = new SeedClient(landscape.kubeconfig)
   const cloudProfilesClient = new CloudProfileClient(landscape.kubeconfig)
   const [
@@ -310,12 +291,15 @@ async function seeds({ parent: landscape }) {
     cloudProfilesClient.list()
   ])
   return _.map(seeds, seed => {
-    const cloudProfile = _.find(cloudProfiles, cloudProfile => cloudProfile.metadata.name === _.get(seed, 'spec.cloud.profile'))
+    const cloudProfile = _.find(
+      cloudProfiles,
+      cloudProfile => cloudProfile.metadata.name === _.get(seed, 'spec.cloud.profile')
+    )
     return toSeedTreeNode(landscape, seed, cloudProfile)
   })
 }
 
-function toSeedTreeNode(landscape, seed, cloudProfile) {
+function toSeedTreeNode (landscape, seed, cloudProfile) {
   const name = _.get(seed, 'metadata.name')
   return {
     nodeType: nodeType.NODE_TYPE_SEED,
@@ -327,11 +311,11 @@ function toSeedTreeNode(landscape, seed, cloudProfile) {
     cloudType: getCloudType(_.get(cloudProfile, 'spec')),
     region: _.get(seed, 'spec.cloud.region', ''),
     visible: _.get(seed, 'spec.visible'),
-    protected: _.get(seed, 'spec.protected'),
+    protected: _.get(seed, 'spec.protected')
   }
 }
 
-function seedTooltip(element) {
+function seedTooltip (element) {
   const list = [
     `Seed: ${element.name}`,
     `Cloud: ${element.cloudType}/${element.region}`,
@@ -341,12 +325,18 @@ function seedTooltip(element) {
   return list.join('\n')
 }
 
-function getCloudType(object) {
-  const cloudTypes = ['aws', 'azure', 'gcp', 'openstack', 'alicloud']
+function getCloudType (object) {
+  const cloudTypes = [
+    'aws',
+    'azure',
+    'gcp',
+    'openstack',
+    'alicloud'
+  ]
   return _.head(_.intersection(_.keys(object), cloudTypes))
 }
 
-function infraIcon(cloudType) {
+function infraIcon (cloudType) {
   const color = iconColor()
   let logo
   switch (cloudType) {
@@ -377,7 +367,7 @@ function infraIcon(cloudType) {
   return vscode.Uri.file(path.join(__dirname, `../assets/${logo}`))
 }
 
-function iconColor() {
+function iconColor () {
   const config = vscode.workspace.getConfiguration('vscode-gardener-tools', null)
   const lightTheme = _.get(config, 'vscode-light-theme', true)
   if (lightTheme) {
@@ -386,7 +376,7 @@ function iconColor() {
   return 'white'
 }
 
-function getFolderIcon(type) {
+function getFolderIcon (type) {
   const color = iconColor()
   switch (type) {
     case nodeType.NODE_TYPE_SHOOT:

--- a/src/gardener/utils.js
+++ b/src/gardener/utils.js
@@ -19,13 +19,13 @@
 const vscode = require('vscode')
 const _ = require('lodash')
 
-function configForLandscape(landscapeName) {
+function configForLandscape (landscapeName) {
   const config = vscode.workspace.getConfiguration('vscode-gardener-tools', null)
   const landscapes = _.get(config, 'landscapes')
   return _.find(landscapes, landscape => landscape.name === landscapeName)
 }
 
-function decodeBase64(value) {
+function decodeBase64 (value) {
   if (!value) {
     return
   }

--- a/src/gardener/utils.js
+++ b/src/gardener/utils.js
@@ -25,7 +25,7 @@ function configForLandscape(landscapeName) {
   return _.find(landscapes, landscape => landscape.name === landscapeName)
 }
 
-function decodeBase64 (value) {
+function decodeBase64(value) {
   if (!value) {
     return
   }

--- a/src/gardener/virtualfs.js
+++ b/src/gardener/virtualfs.js
@@ -33,132 +33,138 @@ const vscode = require('vscode')
 const K8S_RESOURCE_SCHEME = 'gardener'
 const KUBECTL_RESOURCE_AUTHORITY = 'loadkubernetescore'
 
-function kubefsUri(namespace, value, kubeconfigPath, outputFormat) {
-    const docname = `${value.replace('/', '-')}.${outputFormat}`
-    const nonce = new Date().getTime()
-    const nsquery = namespace ? `ns=${namespace}&` : ''
-    const uri = `${K8S_RESOURCE_SCHEME}://${KUBECTL_RESOURCE_AUTHORITY}/${docname}?${nsquery}value=${value}&kubeconfigPath=${kubeconfigPath}&_=${nonce}`
-    return Uri.parse(uri)
+function kubefsUri (namespace, value, kubeconfigPath, outputFormat) {
+  const docname = `${value.replace('/', '-')}.${outputFormat}`
+  const nonce = new Date().getTime()
+  const nsquery = namespace ? `ns=${namespace}&` : ''
+  const uri = `${K8S_RESOURCE_SCHEME}://${KUBECTL_RESOURCE_AUTHORITY}/${docname}?${nsquery}value=${value}&kubeconfigPath=${kubeconfigPath}&_=${nonce}`
+  return Uri.parse(uri)
 }
 
 class KubernetesResourceVirtualFileSystemProvider {
-    constructor(kubectl) {
-      this.kubectl = kubectl
+  constructor (kubectl) {
+    this.kubectl = kubectl
 
-      this.onDidChangeFileEmitter = new EventEmitter()
+    this.onDidChangeFileEmitter = new EventEmitter()
 
-      this.onDidChangeFile = this.onDidChangeFileEmitter.event
+    this.onDidChangeFile = this.onDidChangeFileEmitter.event
+  }
+
+  watch (_uri, _options) {
+    // It would be quite neat to implement this to watch for changes
+    // in the cluster and update the doc accordingly.  But that is very
+    // definitely a future enhancement thing!
+    return new Disposable(() => {})
+  }
+
+  stat (_uri) {
+    return {
+      type: FileType.File,
+      ctime: 0,
+      mtime: 0,
+      size: 65536 // These files don't seem to matter for us
+    }
+  }
+
+  readDirectory (_uri) {
+    return []
+  }
+
+  createDirectory (_uri) {
+    // no-op
+  }
+
+  readFile (uri) {
+    return this.readFileAsync(uri)
+  }
+
+  async readFileAsync (uri) {
+    const content = await this.loadResource(uri)
+    return new Buffer.from(content, 'utf8')
+  }
+
+  async loadResource (uri) {
+    const query = querystring.parse(uri.query)
+
+    const outputFormat = 'yaml'
+    const value = query.value
+    const ns = query.ns
+    const kubeconfigPath = query.kubeconfigPath
+    const resourceAuthority = uri.authority
+
+    const sr = await this.execLoadResource(resourceAuthority, ns, value, kubeconfigPath, outputFormat)
+
+    if (!sr || sr.code !== 0) {
+      const message = sr ? sr.stderr : 'Unable to run command line tool'
+      vscode.window.showErrorMessage('Get command failed: ' + message)
+      throw message
     }
 
-    watch(_uri, _options) {
-        // It would be quite neat to implement this to watch for changes
-        // in the cluster and update the doc accordingly.  But that is very
-        // definitely a future enhancement thing!
-        return new Disposable(() => {})
-    }
+    return sr.stdout
+  }
 
-    stat(_uri) {
+  async execLoadResource (resourceAuthority, ns, value, kubeconfigPath, outputFormat) {
+    switch (resourceAuthority) {
+      case KUBECTL_RESOURCE_AUTHORITY:
+        const nsarg = ns ? `--namespace ${ns}` : ''
+        return await await this.kubectl.api.invokeCommand(
+          `--kubeconfig ${kubeconfigPath} -o ${outputFormat} ${nsarg} get ${value}`
+        )
+      default:
         return {
-            type: FileType.File,
-            ctime: 0,
-            mtime: 0,
-            size: 65536  // These files don't seem to matter for us
+          code: -99,
+          stdout: '',
+          stderr: `Internal error: please raise an issue with the error code InvalidObjectLoadURI and report authority ${resourceAuthority}.`
         }
     }
+  }
 
-    readDirectory(_uri) {
-        return []
+  writeFile (uri, content, _options) {
+    return this.saveAsync(uri, content) // TODO: respect options
+  }
+
+  async saveAsync (uri, content) {
+    // This assumes no pathing in the URI - if this changes, we'll need to
+    // create subdirectories.
+    // TODO: not loving prompting as part of the write when it should really be part of a separate
+    // 'save' workflow - but needs must, I think
+    const rootPath = await selectRootFolder()
+    if (!rootPath) {
+      return
     }
+    const fspath = path.join(rootPath, uri.fsPath)
+    fs.writeFileSync(fspath, content)
+  }
 
-    createDirectory(_uri){
-        // no-op
-    }
+  delete (_uri, _options) {
+    // no-op
+  }
 
-    readFile(uri) {
-        return this.readFileAsync(uri)
-    }
-
-    async readFileAsync(uri) {
-        const content = await this.loadResource(uri)
-        return new Buffer.from(content, 'utf8')
-    }
-
-    async loadResource(uri) {
-        const query = querystring.parse(uri.query)
-
-        const outputFormat = 'yaml'
-        const value = query.value
-        const ns = query.ns
-        const kubeconfigPath = query.kubeconfigPath
-        const resourceAuthority = uri.authority
-
-        const sr = await this.execLoadResource(resourceAuthority, ns, value, kubeconfigPath, outputFormat)
-
-        if (!sr || sr.code !== 0) {
-            const message = sr ? sr.stderr : 'Unable to run command line tool'
-            vscode.window.showErrorMessage('Get command failed: ' + message)
-            throw message
-        }
-
-        return sr.stdout
-    }
-
-    async execLoadResource(resourceAuthority, ns, value, kubeconfigPath, outputFormat) {
-        switch (resourceAuthority) {
-            case KUBECTL_RESOURCE_AUTHORITY:
-                const nsarg = ns ? `--namespace ${ns}` : ''
-                return await await this.kubectl.api.invokeCommand(`--kubeconfig ${kubeconfigPath} -o ${outputFormat} ${nsarg} get ${value}`)
-            default:
-                return { code: -99, stdout: '', stderr: `Internal error: please raise an issue with the error code InvalidObjectLoadURI and report authority ${resourceAuthority}.` }
-        }
-    }
-
-    writeFile(uri, content, _options){
-        return this.saveAsync(uri, content)  // TODO: respect options
-    }
-
-    async saveAsync(uri, content) {
-        // This assumes no pathing in the URI - if this changes, we'll need to
-        // create subdirectories.
-        // TODO: not loving prompting as part of the write when it should really be part of a separate
-        // 'save' workflow - but needs must, I think
-        const rootPath = await selectRootFolder()
-        if (!rootPath) {
-            return
-        }
-        const fspath = path.join(rootPath, uri.fsPath)
-        fs.writeFileSync(fspath, content)
-    }
-
-    delete(_uri, _options){
-        // no-op
-    }
-
-    rename(_oldUri, _newUri, _options){
-        // no-op
-    }
+  rename (_oldUri, _newUri, _options) {
+    // no-op
+  }
 }
 
-async function selectRootFolder() {
+async function selectRootFolder () {
   const folder = await showWorkspaceFolderPick()
   if (!folder) {
-      return undefined
+    return undefined
   }
   if (folder.uri.scheme !== 'file') {
-      vscode.window.showErrorMessage('This command requires a filesystem folder')  // TODO: make it not
-      return undefined
+    vscode.window.showErrorMessage('This command requires a filesystem folder') // TODO: make it not
+    return undefined
   }
   return folder.uri.fsPath
 }
 
-async function showWorkspaceFolderPick() {
+async function showWorkspaceFolderPick () {
   if (!vscode.workspace.workspaceFolders) {
-      vscode.window.showErrorMessage('This command requires an open folder.');
-      return undefined;
+    vscode.window.showErrorMessage('This command requires an open folder.')
+    return undefined
   } else if (vscode.workspace.workspaceFolders.length === 1) {
-      return vscode.workspace.workspaceFolders[0];
+    return vscode.workspace.workspaceFolders[0]
   }
-  return await vscode.window.showWorkspaceFolderPick();
+  return await vscode.window.showWorkspaceFolderPick()
 }
 
 module.exports = {

--- a/src/gardener/vscodeUtils.js
+++ b/src/gardener/vscodeUtils.js
@@ -32,7 +32,7 @@ const shelljs = require('shelljs')
 const sysfs = require('fs')
 const _ = require('lodash')
 
-const EXTENSION_CONFIG_KEY = "vs-kubernetes" // TODO use own property config key
+const EXTENSION_CONFIG_KEY = 'vs-kubernetes' // TODO use own property config key
 
 const WINDOWS = 'win32'
 
@@ -40,10 +40,10 @@ const Platform = {
   Windows: 'windows',
   MacOS: 'mac',
   Linux: 'linux',
-  Unsupported: 'unsupported',  // shouldn't happen!
+  Unsupported: 'unsupported' // shouldn't happen!
 }
 
-async function runAsTerminal(context, command, terminalName) {
+async function runAsTerminal (context, command, terminalName) {
   if (await checkPresent(context, CheckPresentMessageMode.Command)) {
     let execPath = await getPath(context.binName)
     const cmd = command
@@ -57,7 +57,7 @@ async function runAsTerminal(context, command, terminalName) {
   }
 }
 
-function createTerminal(name, shellPath, shellArgs) {
+function createTerminal (name, shellPath, shellArgs) {
   const terminalOptions = {
     name: name,
     shellPath: shellPath,
@@ -67,7 +67,7 @@ function createTerminal(name, shellPath, shellArgs) {
   return vscode.window.createTerminal(terminalOptions)
 }
 
-async function checkPresent(context, errorMessageMode) {
+async function checkPresent (context, errorMessageMode) {
   if (context.binFound || context.pathfinder) {
     return true
   }
@@ -75,7 +75,7 @@ async function checkPresent(context, errorMessageMode) {
   return await checkForBinInternal(context, errorMessageMode)
 }
 
-async function checkForBinInternal(context, errorMessageMode) {
+async function checkForBinInternal (context, errorMessageMode) {
   const binName = context.binName
   const bin = getToolPath(binName)
 
@@ -83,10 +83,17 @@ async function checkForBinInternal(context, errorMessageMode) {
   const inferFailedMessage = `Could not find "${binName}" binary.${contextMessage}`
   const configuredFileMissingMessage = `${bin} does not exist! ${contextMessage}`
 
-  return await checkForBinary(context, bin, binName, inferFailedMessage, configuredFileMissingMessage, errorMessageMode !== CheckPresentMessageMode.Silent)
+  return await checkForBinary(
+    context,
+    bin,
+    binName,
+    inferFailedMessage,
+    configuredFileMissingMessage,
+    errorMessageMode !== CheckPresentMessageMode.Silent
+  )
 }
 
-async function checkForBinary(context, bin, binName, inferFailedMessage, configuredFileMissingMessage, alertOnFail) {
+async function checkForBinary (context, bin, binName, inferFailedMessage, configuredFileMissingMessage, alertOnFail) {
   if (!bin) {
     const fb = await findBinary(binName)
 
@@ -106,7 +113,7 @@ async function checkForBinary(context, bin, binName, inferFailedMessage, configu
     context.binFound = sysfs.existsSync(bin)
   } else {
     const sr = await context.shell.exec(`ls ${bin}`)
-    context.binFound = (!!sr && sr.code === 0)
+    context.binFound = !!sr && sr.code === 0
   }
   if (context.binFound) {
     context.binPath = bin
@@ -119,7 +126,7 @@ async function checkForBinary(context, bin, binName, inferFailedMessage, configu
   return context.binFound
 }
 
-async function findBinary(binName) {
+async function findBinary (binName) {
   let cmd = `which ${binName}`
 
   if (isWindows()) {
@@ -142,62 +149,61 @@ async function findBinary(binName) {
   return { err: null, output: execResult.stdout }
 }
 
-function execCore(cmd, opts, stdin) {
-  return new Promise((resolve) => {
+function execCore (cmd, opts, stdin) {
+  return new Promise(resolve => {
     if (getUseWsl()) {
       cmd = 'wsl ' + cmd
     }
-    const proc = shelljs.exec(cmd, opts, (code, stdout, stderr) => resolve({ code: code, stdout: stdout, stderr: stderr }))
+    const proc = shelljs.exec(cmd, opts, (code, stdout, stderr) =>
+      resolve({ code: code, stdout: stdout, stderr: stderr })
+    )
     if (stdin) {
       proc.stdin.end(stdin)
     }
   })
 }
 
-function alertNoBin(binName, failureReason, message, installDependencies) {
+function alertNoBin (binName, failureReason, message, installDependencies) {
   switch (failureReason) {
     case 'inferFailed':
-      showErrorMessage(message, 'Install dependencies', 'Learn more').then(
-        (str) => {
-          switch (str) {
-            case 'Learn more':
-              showInformationMessage(`Add ${binName} directory to path, or set "vs-kubernetes.${binName}-path" config to ${binName} binary.`)
-              break
-            case 'Install dependencies':
-              installDependencies()
-              break
-          }
-
+      showErrorMessage(message, 'Install dependencies', 'Learn more').then(str => {
+        switch (str) {
+          case 'Learn more':
+            showInformationMessage(
+              `Add ${binName} directory to path, or set "vs-kubernetes.${binName}-path" config to ${binName} binary.`
+            )
+            break
+          case 'Install dependencies':
+            installDependencies()
+            break
         }
-      )
+      })
       break
     case 'configuredFileMissing':
-      showErrorMessage(message, 'Install dependencies').then(
-        (str) => {
-          if (str === 'Install dependencies') {
-            installDependencies()
-          }
+      showErrorMessage(message, 'Install dependencies').then(str => {
+        if (str === 'Install dependencies') {
+          installDependencies()
         }
-      )
+      })
       break
   }
 }
 
-function showErrorMessage(message, ...items) {
+function showErrorMessage (message, ...items) {
   return vscode.window.showErrorMessage(message, ...items)
 }
 
-function showInformationMessage(message, ...items) {
+function showInformationMessage (message, ...items) {
   return vscode.window.showInformationMessage(message, ...items)
 }
 
 const CheckPresentMessageMode = {
   Command: 'command',
   Activation: 'activation',
-  Silent: 'silent',
+  Silent: 'silent'
 }
 
-function getCheckContextMessage(errorMessageMode) {
+function getCheckContextMessage (errorMessageMode) {
   if (errorMessageMode === CheckPresentMessageMode.Activation) {
     return ' Kubernetes commands other than configuration will not function correctly.'
   } else if (errorMessageMode === CheckPresentMessageMode.Command) {
@@ -206,10 +212,10 @@ function getCheckContextMessage(errorMessageMode) {
   return ''
 }
 
-function shellEnvironment(baseEnvironment) {
+function shellEnvironment (baseEnvironment) {
   const env = Object.assign({}, baseEnvironment)
   const pathVariable = pathVariableName(env)
-  for (const tool of ['gardenctl']) {
+  for (const tool of [ 'gardenctl' ]) {
     const toolPath = getToolPath(tool)
     if (toolPath) {
       const toolDirectory = path.dirname(toolPath)
@@ -226,83 +232,91 @@ function shellEnvironment(baseEnvironment) {
   return env
 }
 
-function pathEntrySeparator() {
+function pathEntrySeparator () {
   return isWindows() ? '' : ':'
 }
 
-function pathVariableName(env) {
+function pathVariableName (env) {
   if (isWindows()) {
     for (const v of Object.keys(env)) {
-      if (v.toLowerCase() === "path") {
+      if (v.toLowerCase() === 'path') {
         return v
       }
     }
   }
-  return "PATH"
+  return 'PATH'
 }
 
-function isWindows() {
-  return (process.platform === WINDOWS) && !getUseWsl()
+function isWindows () {
+  return process.platform === WINDOWS && !getUseWsl()
 }
 
 // Use WSL on Windows
-const USE_WSL_KEY = "use-wsl"
+const USE_WSL_KEY = 'use-wsl'
 
-function getUseWsl() {
+function getUseWsl () {
   return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[USE_WSL_KEY]
 }
 
-function getToolPath(tool) {
+function getToolPath (tool) {
   const baseKey = toolPathBaseKey(tool)
   return getPathSetting(baseKey)
 }
 
-function getPathSetting(baseKey) {
+function getPathSetting (baseKey) {
   const os = platform()
   const osOverridePath = getConfiguration(EXTENSION_CONFIG_KEY)[osOverrideKey(os, baseKey)]
   return osOverridePath || getConfiguration(EXTENSION_CONFIG_KEY)[baseKey]
 }
 
-function getConfiguration(key) {
+function getConfiguration (key) {
   return vscode.workspace.getConfiguration(key)
 }
 
-function platform() {
+function platform () {
   if (getUseWsl()) {
     return Platform.Linux
   }
   switch (process.platform) {
-    case 'win32': return Platform.Windows
-    case 'darwin': return Platform.MacOS
-    case 'linux': return Platform.Linux
-    default: return Platform.Unsupported
+    case 'win32':
+      return Platform.Windows
+    case 'darwin':
+      return Platform.MacOS
+    case 'linux':
+      return Platform.Linux
+    default:
+      return Platform.Unsupported
   }
 }
 
-function toolPathBaseKey(tool) {
+function toolPathBaseKey (tool) {
   return `vs-kubernetes.${tool}-path` // TODO use own property
 }
 
-function osOverrideKey(os, baseKey) {
+function osOverrideKey (os, baseKey) {
   const osKey = osKeyString(os)
-  return osKey ? `${baseKey}.${osKey}` : baseKey  // The 'else' clause should never happen so don't worry that this would result in double-checking a missing base key
+  return osKey ? `${baseKey}.${osKey}` : baseKey // The 'else' clause should never happen so don't worry that this would result in double-checking a missing base key
 }
 
-function osKeyString(os) {
+function osKeyString (os) {
   switch (os) {
-    case Platform.Windows: return 'windows'
-    case Platform.MacOS: return 'mac'
-    case Platform.Linux: return 'linux'
-    default: return null
+    case Platform.Windows:
+      return 'windows'
+    case Platform.MacOS:
+      return 'mac'
+    case Platform.Linux:
+      return 'linux'
+    default:
+      return null
   }
 }
 
-async function getPath(binName) {
+async function getPath (binName) {
   const bin = await basePath(binName)
   return execPath(bin)
 }
 
-async function basePath(binName) {
+async function basePath (binName) {
   // if (context.pathfinder) {
   //     return await context.pathfinder()
   // }
@@ -313,7 +327,7 @@ async function basePath(binName) {
   return bin
 }
 
-async function invokeInTerminal(context, command, pipeTo, terminal) {
+async function invokeInTerminal (context, command, pipeTo, terminal) {
   if (await checkPresent(context, CheckPresentMessageMode.Command)) {
     // You might be tempted to think we needed to add 'wsl' here if user is using wsl
     // but this runs in the context of a vanilla terminal, which is controlled by the
@@ -326,7 +340,7 @@ async function invokeInTerminal(context, command, pipeTo, terminal) {
   }
 }
 
-async function invoke(context, command) {
+async function invoke (context, command) {
   return new Promise(async function (resolve, reject) {
     try {
       await toolInternal(context, command, (code, stdout, stderr) => {
@@ -343,7 +357,7 @@ async function invoke(context, command) {
   })
 }
 
-async function toolInternal(context, command, handler) {
+async function toolInternal (context, command, handler) {
   if (await checkPresent(context, CheckPresentMessageMode.Command)) {
     const bin = await basePath(context.binName)
     const cmd = `${bin} ${command}`
@@ -354,7 +368,7 @@ async function toolInternal(context, command, handler) {
   }
 }
 
-function execOpts() {
+function execOpts () {
   let env = process.env
   if (isWindows()) {
     env = Object.assign({}, env, { HOME: home() })
@@ -368,7 +382,7 @@ function execOpts() {
   return opts
 }
 
-async function exec(cmd, stdin) {
+async function exec (cmd, stdin) {
   try {
     return await execCore(cmd, execOpts(), null, stdin)
   } catch (ex) {
@@ -377,37 +391,38 @@ async function exec(cmd, stdin) {
   }
 }
 
-function home() {
+function home () {
   if (getUseWsl()) {
     return shelljs.exec('wsl.exe echo ${HOME}').stdout.trim()
   }
-  return process.env['HOME'] ||
+  return (
+    process.env['HOME'] ||
     concatIfBoth(process.env['HOMEDRIVE'], process.env['HOMEPATH']) ||
     process.env['USERPROFILE'] ||
     ''
+  )
 }
 
-function concatIfBoth(s1, s2) {
+function concatIfBoth (s1, s2) {
   return s1 && s2 ? s1.concat(s2) : undefined
 }
 
-function onDidCloseTerminal(listener) {
+function onDidCloseTerminal (listener) {
   return vscode.window.onDidCloseTerminal(listener)
 }
 
-
-function execPath(basePath) {
+function execPath (basePath) {
   let bin = basePath
-  if (isWindows() && bin && !(bin.endsWith('.exe'))) {
+  if (isWindows() && bin && !bin.endsWith('.exe')) {
     bin = bin + '.exe'
   }
   return bin
 }
 
 class GardenctlImpl {
-  constructor(binFound = false) {
+  constructor (binFound = false) {
     this.context = {
-      installDependenciesCallback: () => { }, // TODO
+      installDependenciesCallback: () => {}, // TODO
       pathfinder: undefined, // TODO
       binFound,
       binPath: 'gardenctl',
@@ -415,29 +430,29 @@ class GardenctlImpl {
     }
   }
 
-  checkPresent(errorMessageMode) {
+  checkPresent (errorMessageMode) {
     return checkPresent(this.context, errorMessageMode)
   }
-  async invoke(command) {
+  async invoke (command) {
     return invoke(this.context, command)
   }
-  async invokeInNewTerminal(command, terminalName, onClose, pipeTo) {
+  async invokeInNewTerminal (command, terminalName, onClose, pipeTo) {
     const terminal = createTerminal(terminalName)
-    const disposable = onClose ? onDidCloseTerminal(onClose) : new vscode.Disposable(() => { })
+    const disposable = onClose ? onDidCloseTerminal(onClose) : new vscode.Disposable(() => {})
     await invokeInTerminal(this.context, command, pipeTo, terminal)
     return disposable
   }
-  invokeInSharedTerminal(command) {
+  invokeInSharedTerminal (command) {
     const terminal = this.getSharedTerminal()
     return invokeInTerminal(this.context, command, undefined, terminal)
   }
-  runAsTerminal(command, terminalName) {
+  runAsTerminal (command, terminalName) {
     return runAsTerminal(this.context, command, terminalName)
   }
-  getSharedTerminal() {
+  getSharedTerminal () {
     if (!this.sharedTerminal) {
       this.sharedTerminal = createTerminal('gardenctl')
-      const disposable = onDidCloseTerminal((terminal) => {
+      const disposable = onDidCloseTerminal(terminal => {
         if (terminal === this.sharedTerminal) {
           this.sharedTerminal = null
           disposable.dispose()

--- a/src/gardener/vscodeUtils.js
+++ b/src/gardener/vscodeUtils.js
@@ -1,0 +1,453 @@
+// forked from https://github.com/Azure/vscode-kubernetes-tools
+
+//
+// MIT License
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE
+//
+
+'use strict'
+
+const vscode = require('vscode')
+const path = require('path')
+const shelljs = require('shelljs')
+const sysfs = require('fs')
+const _ = require('lodash')
+
+const EXTENSION_CONFIG_KEY = "vs-kubernetes" // TODO use own property config key
+
+const WINDOWS = 'win32'
+
+const Platform = {
+  Windows: 'windows',
+  MacOS: 'mac',
+  Linux: 'linux',
+  Unsupported: 'unsupported',  // shouldn't happen!
+}
+
+async function runAsTerminal(context, command, terminalName) {
+  if (await checkPresent(context, CheckPresentMessageMode.Command)) {
+    let execPath = await getPath(context.binName)
+    const cmd = command
+    if (getUseWsl()) {
+      cmd.unshift(execPath)
+      // Note VS Code is picky here. It requires the '.exe' to work
+      execPath = 'wsl.exe'
+    }
+    const term = createTerminal(terminalName, execPath, cmd)
+    term.show()
+  }
+}
+
+function createTerminal(name, shellPath, shellArgs) {
+  const terminalOptions = {
+    name: name,
+    shellPath: shellPath,
+    shellArgs: shellArgs,
+    env: shellEnvironment(process.env)
+  }
+  return vscode.window.createTerminal(terminalOptions)
+}
+
+async function checkPresent(context, errorMessageMode) {
+  if (context.binFound || context.pathfinder) {
+    return true
+  }
+
+  return await checkForBinInternal(context, errorMessageMode)
+}
+
+async function checkForBinInternal(context, errorMessageMode) {
+  const binName = context.binName
+  const bin = getToolPath(binName)
+
+  const contextMessage = getCheckContextMessage(errorMessageMode)
+  const inferFailedMessage = `Could not find "${binName}" binary.${contextMessage}`
+  const configuredFileMissingMessage = `${bin} does not exist! ${contextMessage}`
+
+  return await checkForBinary(context, bin, binName, inferFailedMessage, configuredFileMissingMessage, errorMessageMode !== CheckPresentMessageMode.Silent)
+}
+
+async function checkForBinary(context, bin, binName, inferFailedMessage, configuredFileMissingMessage, alertOnFail) {
+  if (!bin) {
+    const fb = await findBinary(binName)
+
+    if (fb.err || fb.output.length === 0) {
+      if (alertOnFail) {
+        alertNoBin(binName, 'inferFailed', inferFailedMessage, context.installDependenciesCallback)
+      }
+      return false
+    }
+
+    context.binFound = true
+
+    return true
+  }
+
+  if (!getUseWsl()) {
+    context.binFound = sysfs.existsSync(bin)
+  } else {
+    const sr = await context.shell.exec(`ls ${bin}`)
+    context.binFound = (!!sr && sr.code === 0)
+  }
+  if (context.binFound) {
+    context.binPath = bin
+  } else {
+    if (alertOnFail) {
+      alertNoBin(binName, 'configuredFileMissing', configuredFileMissingMessage, context.installDependenciesCallback)
+    }
+  }
+
+  return context.binFound
+}
+
+async function findBinary(binName) {
+  let cmd = `which ${binName}`
+
+  if (isWindows()) {
+    cmd = `where.exe ${binName}.exe`
+  }
+
+  const opts = {
+    async: true,
+    env: {
+      HOME: process.env.HOME,
+      PATH: process.env.PATH
+    }
+  }
+
+  const execResult = await execCore(cmd, opts)
+  if (execResult.code) {
+    return { err: execResult.code, output: execResult.stderr }
+  }
+
+  return { err: null, output: execResult.stdout }
+}
+
+function execCore(cmd, opts, stdin) {
+  return new Promise((resolve) => {
+    if (getUseWsl()) {
+      cmd = 'wsl ' + cmd
+    }
+    const proc = shelljs.exec(cmd, opts, (code, stdout, stderr) => resolve({ code: code, stdout: stdout, stderr: stderr }))
+    if (stdin) {
+      proc.stdin.end(stdin)
+    }
+  })
+}
+
+function alertNoBin(binName, failureReason, message, installDependencies) {
+  switch (failureReason) {
+    case 'inferFailed':
+      showErrorMessage(message, 'Install dependencies', 'Learn more').then(
+        (str) => {
+          switch (str) {
+            case 'Learn more':
+              showInformationMessage(`Add ${binName} directory to path, or set "vs-kubernetes.${binName}-path" config to ${binName} binary.`)
+              break
+            case 'Install dependencies':
+              installDependencies()
+              break
+          }
+
+        }
+      )
+      break
+    case 'configuredFileMissing':
+      showErrorMessage(message, 'Install dependencies').then(
+        (str) => {
+          if (str === 'Install dependencies') {
+            installDependencies()
+          }
+        }
+      )
+      break
+  }
+}
+
+function showErrorMessage(message, ...items) {
+  return vscode.window.showErrorMessage(message, ...items)
+}
+
+function showInformationMessage(message, ...items) {
+  return vscode.window.showInformationMessage(message, ...items)
+}
+
+const CheckPresentMessageMode = {
+  Command: 'command',
+  Activation: 'activation',
+  Silent: 'silent',
+}
+
+function getCheckContextMessage(errorMessageMode) {
+  if (errorMessageMode === CheckPresentMessageMode.Activation) {
+    return ' Kubernetes commands other than configuration will not function correctly.'
+  } else if (errorMessageMode === CheckPresentMessageMode.Command) {
+    return ' Cannot execute command.'
+  }
+  return ''
+}
+
+function shellEnvironment(baseEnvironment) {
+  const env = Object.assign({}, baseEnvironment)
+  const pathVariable = pathVariableName(env)
+  for (const tool of ['gardenctl']) {
+    const toolPath = getToolPath(tool)
+    if (toolPath) {
+      const toolDirectory = path.dirname(toolPath)
+      const currentPath = env[pathVariable]
+      env[pathVariable] = toolDirectory + (currentPath ? `${pathEntrySeparator()}${currentPath}` : '')
+    }
+  }
+
+  // const kubeconfig = getActiveKubeconfig()
+  // if (kubeconfig) {
+  //     env['KUBECONFIG'] = kubeconfig
+  // }
+
+  return env
+}
+
+function pathEntrySeparator() {
+  return isWindows() ? '' : ':'
+}
+
+function pathVariableName(env) {
+  if (isWindows()) {
+    for (const v of Object.keys(env)) {
+      if (v.toLowerCase() === "path") {
+        return v
+      }
+    }
+  }
+  return "PATH"
+}
+
+function isWindows() {
+  return (process.platform === WINDOWS) && !getUseWsl()
+}
+
+// Use WSL on Windows
+const USE_WSL_KEY = "use-wsl"
+
+function getUseWsl() {
+  return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[USE_WSL_KEY]
+}
+
+function getToolPath(tool) {
+  const baseKey = toolPathBaseKey(tool)
+  return getPathSetting(baseKey)
+}
+
+function getPathSetting(baseKey) {
+  const os = platform()
+  const osOverridePath = getConfiguration(EXTENSION_CONFIG_KEY)[osOverrideKey(os, baseKey)]
+  return osOverridePath || getConfiguration(EXTENSION_CONFIG_KEY)[baseKey]
+}
+
+function getConfiguration(key) {
+  return vscode.workspace.getConfiguration(key)
+}
+
+function platform() {
+  if (getUseWsl()) {
+    return Platform.Linux
+  }
+  switch (process.platform) {
+    case 'win32': return Platform.Windows
+    case 'darwin': return Platform.MacOS
+    case 'linux': return Platform.Linux
+    default: return Platform.Unsupported
+  }
+}
+
+function toolPathBaseKey(tool) {
+  return `vs-kubernetes.${tool}-path` // TODO use own property
+}
+
+function osOverrideKey(os, baseKey) {
+  const osKey = osKeyString(os)
+  return osKey ? `${baseKey}.${osKey}` : baseKey  // The 'else' clause should never happen so don't worry that this would result in double-checking a missing base key
+}
+
+function osKeyString(os) {
+  switch (os) {
+    case Platform.Windows: return 'windows'
+    case Platform.MacOS: return 'mac'
+    case Platform.Linux: return 'linux'
+    default: return null
+  }
+}
+
+async function getPath(binName) {
+  const bin = await basePath(binName)
+  return execPath(bin)
+}
+
+async function basePath(binName) {
+  // if (context.pathfinder) {
+  //     return await context.pathfinder()
+  // }
+  let bin = getToolPath(binName)
+  if (!bin) {
+    bin = binName
+  }
+  return bin
+}
+
+async function invokeInTerminal(context, command, pipeTo, terminal) {
+  if (await checkPresent(context, CheckPresentMessageMode.Command)) {
+    // You might be tempted to think we needed to add 'wsl' here if user is using wsl
+    // but this runs in the context of a vanilla terminal, which is controlled by the
+    // existing preference, so it's not necessary.
+    // But a user does need to default VS code to use WSL in the settings.json
+    const binCommand = `${context.binName} ${command}`
+    const fullCommand = pipeTo ? `${binCommand} | ${pipeTo}` : binCommand
+    terminal.sendText(fullCommand)
+    terminal.show()
+  }
+}
+
+async function invoke(context, command) {
+  return new Promise(async function (resolve, reject) {
+    try {
+      await toolInternal(context, command, (code, stdout, stderr) => {
+        if (code !== 0) {
+          const errMessage = _.isEmpty(stderr) ? stdout : stderr
+          reject(new Error(errMessage))
+          return
+        }
+        resolve(stdout)
+      })
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+async function toolInternal(context, command, handler) {
+  if (await checkPresent(context, CheckPresentMessageMode.Command)) {
+    const bin = await basePath(context.binName)
+    const cmd = `${bin} ${command}`
+    const sr = await exec(cmd)
+    if (sr) {
+      handler(sr.code, sr.stdout, sr.stderr)
+    }
+  }
+}
+
+function execOpts() {
+  let env = process.env
+  if (isWindows()) {
+    env = Object.assign({}, env, { HOME: home() })
+  }
+  env = shellEnvironment(env)
+  const opts = {
+    cwd: vscode.workspace.rootPath,
+    env: env,
+    async: true
+  }
+  return opts
+}
+
+async function exec(cmd, stdin) {
+  try {
+    return await execCore(cmd, execOpts(), null, stdin)
+  } catch (ex) {
+    vscode.window.showErrorMessage(ex)
+    return undefined
+  }
+}
+
+function home() {
+  if (getUseWsl()) {
+    return shelljs.exec('wsl.exe echo ${HOME}').stdout.trim()
+  }
+  return process.env['HOME'] ||
+    concatIfBoth(process.env['HOMEDRIVE'], process.env['HOMEPATH']) ||
+    process.env['USERPROFILE'] ||
+    ''
+}
+
+function concatIfBoth(s1, s2) {
+  return s1 && s2 ? s1.concat(s2) : undefined
+}
+
+function onDidCloseTerminal(listener) {
+  return vscode.window.onDidCloseTerminal(listener)
+}
+
+
+function execPath(basePath) {
+  let bin = basePath
+  if (isWindows() && bin && !(bin.endsWith('.exe'))) {
+    bin = bin + '.exe'
+  }
+  return bin
+}
+
+class GardenctlImpl {
+  constructor(binFound = false) {
+    this.context = {
+      installDependenciesCallback: () => { }, // TODO
+      pathfinder: undefined, // TODO
+      binFound,
+      binPath: 'gardenctl',
+      binName: 'gardenctl'
+    }
+  }
+
+  checkPresent(errorMessageMode) {
+    return checkPresent(this.context, errorMessageMode)
+  }
+  async invoke(command) {
+    return invoke(this.context, command)
+  }
+  async invokeInNewTerminal(command, terminalName, onClose, pipeTo) {
+    const terminal = createTerminal(terminalName)
+    const disposable = onClose ? onDidCloseTerminal(onClose) : new vscode.Disposable(() => { })
+    await invokeInTerminal(this.context, command, pipeTo, terminal)
+    return disposable
+  }
+  invokeInSharedTerminal(command) {
+    const terminal = this.getSharedTerminal()
+    return invokeInTerminal(this.context, command, undefined, terminal)
+  }
+  runAsTerminal(command, terminalName) {
+    return runAsTerminal(this.context, command, terminalName)
+  }
+  getSharedTerminal() {
+    if (!this.sharedTerminal) {
+      this.sharedTerminal = createTerminal('gardenctl')
+      const disposable = onDidCloseTerminal((terminal) => {
+        if (terminal === this.sharedTerminal) {
+          this.sharedTerminal = null
+          disposable.dispose()
+        }
+      })
+    }
+    return this.sharedTerminal
+  }
+}
+
+module.exports = {
+  GardenctlImpl
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for gardenctl `target` and `shell` support.
Gardenctl has to be installed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
`Gardenctl` support
- Right click on shoot or seed to get a `Shell` to a node
- Right click on landscape, project, shoot or seed to `Target` with `gardenctl`
```

```improvement user
There is a new optional setting `vscode-gardener-tools.landscapes[].gardenName` to specify the name of the corresponding (`gardenctl`) garden.
```
