### PR TITLE
Add listing support for backupBucket and backupEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This `Visual Studio Code Kubernetes Tools` extension allows you to work with you
 - List shoot clusters
 - List plant clusters
 - List backup infrastructure resources
+- List backup bucket resources
+- List backup entry resources
 - List seed clusters
 - Right click on landscape, shoot, plant or seed cluster to `Save Kubeconfig` / `Merge into Kubeconfig`
 - Right click landscape or shoot to `Show In Dashboard`

--- a/src/gardener/client.js
+++ b/src/gardener/client.js
@@ -112,6 +112,18 @@ class PlantClient extends Client {
   }
 }
 
+
+class BackupBucketClient extends Client {
+  constructor (kubeconfig) {
+    const namespace = undefined // BackupBucket is a cluster scoped resource
+    super(kubeconfig, namespace, 'backupbuckets')
+  }
+}
+class BackupEntryClient extends Client {
+  constructor (kubeconfig, namespace) {
+    super(kubeconfig, namespace, 'backupentries')
+  }
+}
 class BackupInfraClient extends Client {
   constructor (kubeconfig, namespace) {
     super(kubeconfig, namespace, 'backupinfrastructures')
@@ -165,6 +177,8 @@ module.exports = {
   ProjectClient,
   ShootClient,
   PlantClient,
+  BackupBucketClient,
+  BackupEntryClient,
   BackupInfraClient,
   SeedClient,
   SecretClient,

--- a/src/gardener/gardener-tree.js
+++ b/src/gardener/gardener-tree.js
@@ -342,8 +342,8 @@ function toBackupBucketTreeNode (landscape, backupBucket) {
     name,
     landscape,
     seed: _.get(backupBucket, 'spec.seed'),
-    region: _.get(backupBucket, 'spec.region'),
-    cloudType: _.get(backupBucket, 'spec.provider'),
+    region: _.get(backupBucket, 'spec.provider.region'),
+    cloudType: _.get(backupBucket, 'spec.provider.type'),
   }
 }
 
@@ -385,7 +385,7 @@ function toBackupEntryTreeNode (project, backupEntry, backupBucket) {
     project,
     bucket: _.get(backupEntry, 'spec.bucketName'),
     seed: _.get(backupEntry, 'spec.seed'),
-    cloudType: _.get(backupBucket, 'spec.provider'),
+    cloudType: _.get(backupBucket, 'spec.provider.type'),
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR adds the support for listing backupBucket and backupEntry resources in garden cluster.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Added support for `BackupBucket` and `BackupEntry` resource
```
