### PR TITLE
Add Register / Unregister Command

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline_temp$",
     "lines": null
   },
-  "generated_at": "2019-10-18T13:46:35Z",
+  "generated_at": "2019-11-14T08:31:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -34,7 +34,7 @@
       {
         "hashed_secret": "30118aa1aa8a06fa5365743b3a5db69fc62b9760",
         "is_secret": false,
-        "line_number": 491,
+        "line_number": 520,
         "type": "Secret Keyword"
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline_temp$",
     "lines": null
   },
-  "generated_at": "2019-11-14T08:31:30Z",
+  "generated_at": "2019-11-15T12:33:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -34,7 +34,7 @@
       {
         "hashed_secret": "30118aa1aa8a06fa5365743b3a5db69fc62b9760",
         "is_secret": false,
-        "line_number": 520,
+        "line_number": 533,
         "type": "Secret Keyword"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This `Visual Studio Code Kubernetes Tools` extension allows you to work with you
 - [Gardenctl](https://github.com/gardener/gardenctl) integration
   - Right click on shoot or seed to get a `Shell` to a node
   - Right click on landscape, project, shoot or seed to `Target` with gardenctl
+  - Right click on landscape to `Register` / `Unregister` for the operator shift with gardenctl
 
 ## Requirements
 - You have installed the [Kubernetes Tools](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension from the marketplace

--- a/package.json
+++ b/package.json
@@ -112,6 +112,16 @@
         "category": "Gardener"
       },
       {
+        "command": "vs-gardener.register",
+        "title": "Landscape Admin - Register",
+        "category": "Gardener"
+      },
+      {
+        "command": "vs-gardener.unregister",
+        "title": "Landscape Admin - Unregister",
+        "category": "Gardener"
+      },
+      {
         "command": "vs-gardener.target",
         "title": "Target",
         "category": "Gardener"
@@ -143,6 +153,14 @@
         },
         {
           "command": "vs-gardener.showInDashboard",
+          "when": "viewItem =~ /gardener\\.landscape/i"
+        },
+        {
+          "command": "vs-gardener.register",
+          "when": "viewItem =~ /gardener\\.landscape/i"
+        },
+        {
+          "command": "vs-gardener.unregister",
           "when": "viewItem =~ /gardener\\.landscape/i"
         },
         {

--- a/package.json
+++ b/package.json
@@ -164,6 +164,14 @@
           "when": "viewItem =~ /gardener\\.landscape/i"
         },
         {
+          "command": "vs-gardener.register",
+          "when": "viewItem =~ /kubernetes\\.cloudExplorer\\.cloud\\.Gardener/i"
+        },
+        {
+          "command": "vs-gardener.unregister",
+          "when": "viewItem =~ /kubernetes\\.cloudExplorer\\.cloud\\.Gardener/i"
+        },
+        {
           "command": "vs-gardener.openExtensionSettings",
           "when": "viewItem =~ /kubernetes\\.cloudExplorer\\.cloud\\.Gardener/i"
         },

--- a/package.json
+++ b/package.json
@@ -164,6 +164,10 @@
           "when": "viewItem =~ /gardener\\.landscape/i"
         },
         {
+          "command": "vs-gardener.openExtensionSettings",
+          "when": "viewItem =~ /kubernetes\\.cloudExplorer\\.cloud\\.Gardener/i"
+        },
+        {
           "command": "vs-gardener.createShoot",
           "when": "viewItem =~ /gardener\\.folder\\.shoot/i"
         },


### PR DESCRIPTION
**What this PR does / why we need it**:
As an operator of a landscape you can now register / unregister as cluster/landscape admin for your operator shift.
 Register/Unregister:
- For all landscapes: right click on the the top level node `Gardener` and select `Register`/`Unregister`
- For one specific landscape: right click on the landscape node and select `Register`/`Unregister`

**Which issue(s) this PR fixes**:
Fixes #5 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`Register`/`Unregister` for operator shift:
- For all landscapes: right click on the the top level node `Gardener` and select `Register`/`Unregister`
- For one specific landscape: right click on the landscape node and select `Register`/`Unregister`
```
