### PR TITLE
Support gardenctl ls command

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline_temp$",
     "lines": null
   },
-  "generated_at": "2019-11-15T12:33:14Z",
+  "generated_at": "2019-11-15T16:20:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -34,7 +34,7 @@
       {
         "hashed_secret": "30118aa1aa8a06fa5365743b3a5db69fc62b9760",
         "is_secret": false,
-        "line_number": 533,
+        "line_number": 583,
         "type": "Secret Keyword"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -8,26 +8,30 @@ This `Visual Studio Code Kubernetes Tools` extension allows you to work with you
 
 ## Features
 
-- List gardener projects
-- List shoot clusters
-- List plant clusters
-- List backup infrastructure resources
-- List backup bucket resources
-- List backup entry resources
-- List seed clusters
+- List
+  - gardener projects
+  - shoot clusters
+  - plant clusters
+  - seed clusters [*]
+  - backup infrastructure resources [*]
+  - backup bucket resources [*]
+  - backup entry resources [*]
 - Right click on landscape, shoot, plant or seed cluster to `Save Kubeconfig` / `Merge into Kubeconfig`
-- Right click landscape or shoot to `Show In Dashboard`
+- Right click on landscape or shoot to `Show In Dashboard`
 - Right click on landscape to `Create Project` in gardener dashboard
 - Right click on shoots list to `Create Shoot` in gardener dashboard
 - [Gardenctl](https://github.com/gardener/gardenctl) integration
-  - Right click on shoot or seed to get a `Shell` to a node
-  - Right click on landscape, project, shoot or seed to `Target` with gardenctl
-  - Right click on landscape to `Register` / `Unregister` for the operator shift with gardenctl
+  - Right click on shoot or seed to get a `Shell` to a node [*]
+  - Right click on landscape, project, shoot or seed to `Target` with gardenctl [*]
+  - Right click on landscape, project, shoot or seed to `List` with gardenctl `gardens`, `projects`, `seeds`, `shoots` or `issues`. [*]
+  - Right click on landscape to `Register` / `Unregister` for the operator shift with gardenctl [*]
+
+[*] Gardener operator only
 
 ## Requirements
 - You have installed the [Kubernetes Tools](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension from the marketplace
 - Kubeconfig to (virtual) garden cluster
-- For gardener operators: [Gardenctl](https://github.com/gardener/gardenctl#installation) for `Shell` or `Target` command
+- For gardener operators: [Gardenctl](https://github.com/gardener/gardenctl#installation) for `Shell`, `Target` or `List` command
 
 ## Install
 1. [Install this extension from the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gardener.vscode-gardener-tools)

--- a/package.json
+++ b/package.json
@@ -128,12 +128,17 @@
       },
       {
         "command": "vs-gardener.shell",
-        "title": "Shell",
+        "title": "Shell..",
         "category": "Gardener"
       },
       {
         "command": "vs-gardener.openExtensionSettings",
         "title": "Open Extension Settings",
+        "category": "Gardener"
+      },
+      {
+        "command": "vs-gardener.list",
+        "title": "List..",
         "category": "Gardener"
       }
     ],
@@ -194,6 +199,10 @@
         {
           "command": "vs-gardener.openExtensionSettings",
           "when": "viewItem =~ /gardener\\.configurable/i"
+        },
+        {
+          "command": "vs-gardener.list",
+          "when": "viewItem =~ /gardener\\.listable/i"
         }
       ]
     }

--- a/src/gardener/gardener-tree.js
+++ b/src/gardener/gardener-tree.js
@@ -60,6 +60,10 @@ class GardenerTreeProvider {
     return this.isGardenCtlPresent ? ' gardener.targetable' : ''
   }
 
+  listableContextValue() {
+    return this.isGardenCtlPresent ? ' gardener.listable' : ''
+  }
+
   shellableContextValue(hibernated) {
     return this.isGardenCtlPresent && !hibernated ? ' gardener.shellable' : ''
   }
@@ -81,11 +85,11 @@ class GardenerTreeProvider {
     } else if (element.nodeType === nodeType.NODE_TYPE_LANDSCAPE) {
       const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.Collapsed)
       treeItem.iconPath = vscode.Uri.file(path.join(__dirname, '../assets/gardener-logo.svg'))
-      treeItem.contextValue = `gardener.landscape` + this.targetableContextValue() + ` ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
+      treeItem.contextValue = `gardener.landscape` + this.targetableContextValue() + this.listableContextValue() + ` ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       return treeItem
     } else if (element.nodeType === nodeType.NODE_TYPE_PROJECT) {
       const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.Collapsed)
-      treeItem.contextValue = 'gardener.project' + this.targetableContextValue()
+      treeItem.contextValue = 'gardener.project' + this.targetableContextValue() + this.listableContextValue()
       treeItem.tooltip = projectTooltip(element)
       treeItem.command = getLoadResourceCommand(element)
       return treeItem
@@ -104,7 +108,7 @@ class GardenerTreeProvider {
       }
       const treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None)
       const hibernated = element.hibernated ? '.hibernated' : ''
-      treeItem.contextValue = `gardener.shoot${hibernated}` + this.targetableContextValue() + this.shellableContextValue(element.hibernated) + ` ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
+      treeItem.contextValue = `gardener.shoot${hibernated}` + this.targetableContextValue() + this.listableContextValue() + this.shellableContextValue(element.hibernated) + ` ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
       treeItem.iconPath = infraIcon(element.cloudType)
       treeItem.tooltip = shootTooltip(element)
@@ -118,7 +122,7 @@ class GardenerTreeProvider {
       return treeItem
     } else if (element.nodeType === nodeType.NODE_TYPE_SEED) {
       const treeItem = new vscode.TreeItem(getDisplayName(element), vscode.TreeItemCollapsibleState.None)
-      treeItem.contextValue = `gardener.seed` + this.targetableContextValue() + this.shellableContextValue(false) + `${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
+      treeItem.contextValue = `gardener.seed` + this.targetableContextValue() + this.listableContextValue() + this.shellableContextValue(false) + `${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`
       treeItem.command = getLoadResourceCommand(element)
       treeItem.iconPath = infraIcon(element.cloudType)
       treeItem.tooltip = seedTooltip(element)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `List` context menu entry for `landscape`,  `project`, `shoot` and `seed` node

<img width="987" alt="Screenshot 2019-11-15 at 17 28 31" src="https://user-images.githubusercontent.com/5526658/68959046-9d7b1200-07cd-11ea-80c2-3875958ed283.png">

<img width="996" alt="Screenshot 2019-11-15 at 17 28 20" src="https://user-images.githubusercontent.com/5526658/68959030-93f1aa00-07cd-11ea-9f8b-611a8078ef73.png">
<img width="830" alt="Screenshot 2019-11-15 at 17 28 51" src="https://user-images.githubusercontent.com/5526658/68959060-a5d34d00-07cd-11ea-93b6-249c74217761.png">


**Which issue(s) this PR fixes**:
Fixes #4 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Now supporting `gardenctl ls` command
- You can now right click on `landscape`,  `project`, `shoot` or `seed` node. A QuickInput opens where you can select the resource instance to list like `gardens`, `projects`, `seeds`, `shoots` or `issues`.
- Operator privileges required.
```
