### PR TITLE
Adapt to new gardener resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This `Visual Studio Code Kubernetes Tools` extension allows you to work with you
   - shoot clusters
   - plant clusters
   - seed clusters [*]
-  - backup infrastructure resources [*]
   - backup bucket resources [*]
   - backup entry resources [*]
 - Right click on landscape, shoot, plant or seed cluster to `Save Kubeconfig` / `Merge into Kubeconfig`

--- a/package-lock.json
+++ b/package-lock.json
@@ -796,9 +796,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",

--- a/src/gardener/client.js
+++ b/src/gardener/client.js
@@ -21,6 +21,15 @@ const _ = require('lodash')
 
 const { configForLandscape } = require('./utils')
 
+const GKVEnum = {
+  SHOOTS: 'shoots.v1alpha1.core.gardener.cloud',
+  SEEDS: 'seeds.v1alpha1.core.gardener.cloud',
+  PLANTS: 'plants.v1alpha1.core.gardener.cloud',
+  PROJECTS: 'projects.v1alpha1.core.gardener.cloud',
+  BACKUPBUCKETS: 'backupbuckets.v1alpha1.core.gardener.cloud',
+  BACKUPENTRIES: 'backupentries.v1alpha1.core.gardener.cloud'
+}
+
 class Kubectl {
   constructor (kubeconfig, namespace) {
     this.kubeconfig = kubeconfig
@@ -78,7 +87,7 @@ class Client extends Kubectl {
 class ProjectClient extends Client {
   constructor (kubeconfig, landscapeName) {
     const namespace = undefined // Project is a cluster scoped resource
-    super(kubeconfig, namespace, 'projects')
+    super(kubeconfig, namespace, GKVEnum.PROJECTS)
     this.landscapeName = landscapeName
   }
 
@@ -102,13 +111,13 @@ class ProjectClient extends Client {
 
 class ShootClient extends Client {
   constructor (kubeconfig, namespace) {
-    super(kubeconfig, namespace, 'shoots')
+    super(kubeconfig, namespace, GKVEnum.SHOOTS)
   }
 }
 
 class PlantClient extends Client {
   constructor (kubeconfig, namespace) {
-    super(kubeconfig, namespace, 'plants')
+    super(kubeconfig, namespace, GKVEnum.PLANTS)
   }
 }
 
@@ -116,37 +125,25 @@ class PlantClient extends Client {
 class BackupBucketClient extends Client {
   constructor (kubeconfig) {
     const namespace = undefined // BackupBucket is a cluster scoped resource
-    super(kubeconfig, namespace, 'backupbuckets')
+    super(kubeconfig, namespace, GKVEnum.BACKUPBUCKETS)
   }
 }
 class BackupEntryClient extends Client {
   constructor (kubeconfig, namespace) {
-    super(kubeconfig, namespace, 'backupentries')
-  }
-}
-class BackupInfraClient extends Client {
-  constructor (kubeconfig, namespace) {
-    super(kubeconfig, namespace, 'backupinfrastructures')
+    super(kubeconfig, namespace, GKVEnum.BACKUPENTRIES)
   }
 }
 
 class SeedClient extends Client {
   constructor (kubeconfig) {
     const namespace = undefined // CloudProfile is a cluster scoped resource
-    super(kubeconfig, namespace, 'seeds')
+    super(kubeconfig, namespace, GKVEnum.SEEDS)
   }
 }
 
 class SecretClient extends Client {
   constructor (kubeconfig, namespace) {
     super(kubeconfig, namespace, 'secrets')
-  }
-}
-
-class CloudProfileClient extends Client {
-  constructor (kubeconfig) {
-    const namespace = undefined // CloudProfile is a cluster scoped resource
-    super(kubeconfig, namespace, 'cloudprofiles')
   }
 }
 
@@ -179,10 +176,9 @@ module.exports = {
   PlantClient,
   BackupBucketClient,
   BackupEntryClient,
-  BackupInfraClient,
   SeedClient,
   SecretClient,
-  CloudProfileClient,
   SelfSubjectAccessReviewClient,
-  NodeClient
+  NodeClient,
+  GKVEnum
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adapt to new gardener resources
- Remove deprecated `BackupInfrastructures`. See also https://github.com/gardener/gardener/pull/1453

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Removed deprecated `BackupInfrastructure` resource
```

```improvement user
Now supporting the new gardener resources under the `core.gardener.cloud/v1alpha1` API group
```
